### PR TITLE
Add --stamp-version-string for StringFileInfo blocks

### DIFF
--- a/src/Options.cs
+++ b/src/Options.cs
@@ -16,6 +16,10 @@ public class Options
         HelpText = "The version information to set in the target file (e.g. \"1.2.0.0\").")]
     public Version Version { get; set; }
 
+    [Option("stamp-version-string", SetName = "version",
+        HelpText = "Arbitrary string version information to set in the target file (e.g. \"1.2.3-rc.1\"); should be combined with --stamp-version or --stamp-version-from-file.")]
+    public string VersionString { get; set; }
+
     [Option("stamp-version-from-file", SetName = "version-file",
         HelpText = "A text file containing one line that gets parsed as the target version.")]
     public string TargetVersionFile { get; set; }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -32,10 +32,12 @@ internal class Program
                     TextFileHelper.RegexReplace(o.TargetFile, Patterns.AssemblyFileVersion.Key,
                         string.Format(Patterns.AssemblyFileVersion.Value, o.Version));
                 }
-                
+
                 #endregion
 
                 #region C++/Driver project specific
+
+                string versionString = string.IsNullOrEmpty(o.VersionString) ? o.Version.ToString() : o.VersionString;
                 
                 if (o.OverwriteResourceFileVersion)
                 {
@@ -43,7 +45,7 @@ internal class Program
                         string.Format(Patterns.ResourceFileVersion.Value, o.Version.ToString().Replace('.', ',')),
                         Encoding.Default);
                     TextFileHelper.RegexReplace(o.TargetFile, Patterns.ResourceStringFileVersion.Key,
-                        string.Format(Patterns.ResourceStringFileVersion.Value, o.Version), Encoding.Default);
+                        string.Format(Patterns.ResourceStringFileVersion.Value, versionString), Encoding.Default);
                 }
 
                 if (o.OverwriteResourceProductVersion)
@@ -53,7 +55,7 @@ internal class Program
                             o.Version.ToString().Replace('.', ',')),
                         Encoding.Default);
                     TextFileHelper.RegexReplace(o.TargetFile, Patterns.ResourceStringProductVersion.Key,
-                        string.Format(Patterns.ResourceStringProductVersion.Value, o.Version), Encoding.Default);
+                        string.Format(Patterns.ResourceStringProductVersion.Value, versionString), Encoding.Default);
                 }
 
                 if (o.OverwriteVcxprojInfTimeStamp)


### PR DESCRIPTION
```
./vpatch.exe --stamp-version "1.2.3.4" --resource.file-version --resource.product-version  --target-file C:\Users\fred\code\vicius\src\vīcĭus.rc
```

... creates

```patch
diff --git "a/src/v\304\253c\304\255us.rc" "b/src/v\304\253c\304\255us.rc"
index eeb9251..7d8069a 100644
--- "a/src/v\304\253c\304\255us.rc"
+++ "b/src/v\304\253c\304\255us.rc"
@@ -103,8 +103,8 @@ IDI_ICON_MAIN           ICON                    "favicon.ico"
 //

 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
- PRODUCTVERSION 1,0,0,0
+ FILEVERSION 1,2,3,4
+ PRODUCTVERSION 1,2,3,4
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -121,12 +121,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Nefarius Software Solutions e.U."
             VALUE "FileDescription", "Universal Updater Agent"
-            VALUE "FileVersion", "1.0.0.0"
+VALUE "FileVersion", "1.2.3.4"
             VALUE "InternalName", "Updater.exe"
             VALUE "LegalCopyright", "Copyright (C) 2023 Nefarius Software Solutions e.U."
             VALUE "OriginalFilename", "Updater.exe"
             VALUE "ProductName", "Universal Updater Agent"
-            VALUE "ProductVersion", "1.0.0.0"
+VALUE "ProductVersion", "1.2.3.4"
         END
     END
     BLOCK "VarFileInfo"
```

... and ...

```
./vpatch.exe --stamp-version "1.2.3.4" --stamp-version-string "1.2.3+fredemmott1" --resource.file-version --resource.product-version  --target-file C:\Users\fred\code\vicius\src\vīcĭus.rc
```

... creates

```patch
diff --git "a/src/v\304\253c\304\255us.rc" "b/src/v\304\253c\304\255us.rc"
index eeb9251..a3fd820 100644
--- "a/src/v\304\253c\304\255us.rc"
+++ "b/src/v\304\253c\304\255us.rc"
@@ -103,8 +103,8 @@ IDI_ICON_MAIN           ICON                    "favicon.ico"
 //

 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
- PRODUCTVERSION 1,0,0,0
+ FILEVERSION 1,2,3,4
+ PRODUCTVERSION 1,2,3,4
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -121,12 +121,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Nefarius Software Solutions e.U."
             VALUE "FileDescription", "Universal Updater Agent"
-            VALUE "FileVersion", "1.0.0.0"
+VALUE "FileVersion", "1.2.3+fredemmott1"
             VALUE "InternalName", "Updater.exe"
             VALUE "LegalCopyright", "Copyright (C) 2023 Nefarius Software Solutions e.U."
             VALUE "OriginalFilename", "Updater.exe"
             VALUE "ProductName", "Universal Updater Agent"
-            VALUE "ProductVersion", "1.0.0.0"
+VALUE "ProductVersion", "1.2.3+fredemmott1"
         END
     END
     BLOCK "VarFileInfo"
```

quad-int version is still used for binary versions, string is used just for the string ones.