### PR TITLE
Preserves tabs and spaces on `*.rc` file patching

### DIFF
--- a/src/Patterns.cs
+++ b/src/Patterns.cs
@@ -14,16 +14,16 @@ public static class Patterns
             "[assembly: AssemblyFileVersion(\"{0}\")]");
 
     public static KeyValuePair<string, string> ResourceFileVersion =>
-        new(@"FILEVERSION[ \\t]*\d*,\d*,\d*,\d*", "FILEVERSION {0}");
+        new(@"FILEVERSION(?<spacing>[ \\t]*)\d*,\d*,\d*,\d*", "FILEVERSION${{spacing}}{0}");
 
     public static KeyValuePair<string, string> ResourceProductVersion =>
-        new(@"PRODUCTVERSION[ \\t]*\d*,\d*,\d*,\d*", "PRODUCTVERSION {0}");
+        new(@"PRODUCTVERSION(?<spacing>[ \\t]*)\d*,\d*,\d*,\d*", "PRODUCTVERSION${{spacing}}{0}");
 
     public static KeyValuePair<string, string> ResourceStringFileVersion
-        => new("^[ \\t]*VALUE[ \\t]*\"FileVersion\"[ \\t]*,[ \\t]*\"\\d*\\.\\d*\\.\\d*\\.\\d*\"",
-            "VALUE \"FileVersion\", \"{0}\"");
+        => new("^(?<indent>[ \\t]*)VALUE[ \\t]*\"FileVersion\"[ \\t]*,(?<spacing>[ \\t]*)\"\\d*\\.\\d*\\.\\d*\\.\\d*\"",
+            "${{indent}}VALUE \"FileVersion\",${{spacing}}\"{0}\"");
 
     public static KeyValuePair<string, string> ResourceStringProductVersion
-        => new("^[ \\t]*VALUE[ \\t]*\"ProductVersion\"[ \\t]*,[ \\t]*\"\\d*\\.\\d*\\.\\d*\\.\\d*\"",
-            "VALUE \"ProductVersion\", \"{0}\"");
+        => new("^(?<indent>[ \\t]*)VALUE[ \\t]*\"ProductVersion\"[ \\t]*,(?<spacing>[ \\t]*)\"\\d*\\.\\d*\\.\\d*\\.\\d*\"",
+            "${{indent}}VALUE \"ProductVersion\",${{spacing}}\"{0}\"");
 }

--- a/vpatch.sln
+++ b/vpatch.sln
@@ -20,6 +20,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{83961645-DD45-4661-92C2-477E9219FB11}"
 	ProjectSection(SolutionItems) = preProject
 		examples\driver.vcxproj = examples\driver.vcxproj
+		examples\vbus.rc = examples\vbus.rc
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Changed the regular expressions to preserve the original files' tabs and spaces when patching, see:

![image](https://github.com/user-attachments/assets/d95168c2-93dd-498d-83a9-74ee9b44d80a)
